### PR TITLE
Fix build issues

### DIFF
--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -6,10 +6,11 @@ CXX_STD=CXX11
 #PKG_CPPFLAGS = -DRCPP_USE_UNWIND_PROTECT
 MKDIR_P = ${MKDIR} -p
 PKG_LIBS = @LIBS@
+STATICLIB = SharedObject.a
 
-.PHONY: all create-folder make-static-lib copy-files
+.PHONY: all create-folder copy-files
 
-all: create-folder ${SHLIB} make-static-lib copy-files
+all: ${SHLIB} copy-files
 #all: ${SHLIB}
 
 create-folder:
@@ -17,9 +18,9 @@ create-folder:
 	 ${MKDIR_P} ../inst/include/SharedObject&&\
 	 ${MKDIR_P} ../inst/usrlib${R_ARCH}
 
-make-static-lib:
-	 ${AR} -crv SharedObject.a *.o
+${STATICLIB}: ${OBJECTS}
+	 ${AR} -crv ${STATICLIB} ${OBJECTS}
 
-copy-files:
+copy-files: create-folder ${STATICLIB}
 	 ${CP} "sharedMemory.h" "../inst/include/SharedObject/"&&\
-	 ${CP} "SharedObject.a" "../inst/usrlib${R_ARCH}/"
+	 ${CP} ${STATICLIB} "../inst/usrlib${R_ARCH}/"

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -35,8 +35,8 @@ void sharedMemoryPrint(const char *format, ...){
     {
         va_list args;
         va_start(args, format);
-        vsnprintf(buffer, BUFFER_SIZE, format, args);
-        Rprintf(buffer);
+        Rvprintf(format, args);
+        va_end(args);
     }
 }
 
@@ -45,8 +45,8 @@ void altrepPrint(const char *format, ...){
     {
         va_list args;
         va_start(args, format);
-        vsnprintf(buffer, BUFFER_SIZE, format, args);
-        Rprintf(buffer);
+        Rvprintf(format, args);
+        va_end(args);
     }
 }
 
@@ -55,8 +55,8 @@ void packagePrint(const char *format, ...){
     {
         va_list args;
         va_start(args, format);
-        vsnprintf(buffer, BUFFER_SIZE, format, args);
-        Rprintf(buffer);
+        Rvprintf(format, args);
+        va_end(args);
     }
 }
 


### PR DESCRIPTION
Fix gcc's `-Wformat-security` warnings in `src/utils.cpp` by using the `Rvprintf` function instead of using a temporary buffer and `Rprintf`.

Fix race conditions during build when using parallel `make`. Without this fix, the static library was created before all object files had finished compiling.